### PR TITLE
Add sinon spy test example to readme

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -201,3 +201,29 @@ describe.client.only('Another use case', () => {
 ## Contributing
 
 Please refer to the [main repo contributing info](https://github.com/SUI-Components/sui/blob/master/CONTRIBUTING.md).
+
+## Best practices
+
+### Avoid using `revert` in your tests
+We could do it easily with `revert`. The problem comes when we forget to revert the stub and the mock is affecting other tests.
+
+A better approach would be to create a mock file next to the file we want to mock (the real one).
+
+### Avoid creating new spies in your tests
+It's a common practice to create spies to assert if a function has been called.
+The problem is that spies are not restored automatically after each test, so you have to do it manually.
+
+A better approach is to use `sinon.spy()` to create a spy on an existing function. This way, the spy will be restored automatically after each test.
+
+```javascript
+// Do
+sinon.spy(console, 'error')
+expect(console.error.calledOnce).to.be.true
+// Don't
+const spy = sinon.spy()
+myFunc(spy)
+expect(spy.calledOnce).to.be.true
+```
+
+## Coverage
+By default, a `coverage` folder will be created with an HTML reporter.


### PR DESCRIPTION
## Docs: Add Sinon spy best practices to `sui-test` README

## Description
This PR adds a "Best practices" section to `packages/sui-test/README.md`. It provides guidance and an example for using `sinon.spy()` on existing functions, ensuring spies are automatically restored after tests. This documents the approach for implementing new test cases using Sinon's spy feature, as seen in commit `5c572ba`.

## Related Issue
<!--- No specific issue was provided -->

## Example
The added documentation includes a code example demonstrating the recommended `sinon.spy(object, 'method')` pattern.

---
<a href="https://cursor.com/background-agent?bcId=bc-7af25790-520f-4c64-ae7c-fb0d7addd2e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7af25790-520f-4c64-ae7c-fb0d7addd2e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

